### PR TITLE
Add Gaussian, Poisson, and Bernouilli dists. Allow to modify parameters from sim file

### DIFF
--- a/modules/ranalib_movement.lua
+++ b/modules/ranalib_movement.lua
@@ -7,6 +7,7 @@ local degrees = 57.2958
 -- with a speed of 5 meters pr second
 function ranaLibMovement.to(options)
 
+
 	local xx = options.x or posX
 	local yy = options.y or posY
 	local sspeed = options.speed or Speed
@@ -84,12 +85,102 @@ end
 function ranaLibMovement.setSpeed(speed)
 
 	if type(speed) == "number" and speed > 0 then
-		Speed = speed	
+		Speed = speed
 	end
 
 end
 
-function ranaLibMovement.setDirection(angle)
+-- Sets the X and Y velocity components of the agent
+-- @Param velocity{x, y} in m/s. Can be negative
+function ranaLibMovement.setVelocity(velocity)
+
+	local vx = velocity.x
+	local vy = velocity.y
+
+	local deltaX = -10
+	local deltaY = -10
+
+	local deltaX_2 = 0
+	local deltaY_2 = 0
+
+	-- Get the movement angle, in radians
+	local angle = math.atan2(vy, vx)
+
+	-- Get the absolute speed
+	local speed = math.sqrt(math.pow(vx, 2) + math.pow(vy, 2))
+
+	-- Get the X and Y distances from the agent to the map border, in the
+	-- direction of its movement.
+	if vx > 0 then
+		deltaX = ENV_WIDTH - PositionX
+	elseif vx < 0 then
+		deltaX = PositionX
+	end
+
+	if vy > 0 then
+		deltaY = ENV_HEIGHT - PositionY
+	elseif vy < 0 then
+		deltaY = PositionY
+	end
+
+	-- Get the X and Y distances from the agent to the crossing between the
+	-- projection of its movement and the borders of the map
+	deltaX_2 = math.abs(deltaY / math.tan(angle))
+	deltaY_2 = math.abs(deltaX * math.tan(angle))
+
+	-- Get the destination, based on the projection of the velocity over
+	-- both borders in the map, and the direction of the movement.
+	-- For X component.
+	if deltaY_2 <= deltaX_2 then
+		if vx < 0 then
+			DestinationX = 0
+		elseif vx > 0 then
+			DestinationX = ENV_WIDTH
+		else
+			DestinationX = PositionX
+		end
+	else
+		if vx < 0 then
+			DestinationX = PositionX - deltaX_2
+		elseif vx > 0 then
+			DestinationX = PositionX + deltaX_2
+		else
+			DestinationX = PositionX
+		end
+	end
+	-- For Y component.
+	if deltaY_2 >= deltaX_2 then
+		if vy < 0 then
+			DestinationY = 0
+		elseif vy > 0 then
+			DestinationY = ENV_HEIGHT
+		else
+			DestinationY = PositionY
+		end
+	else
+		if vy < 0 then
+			DestinationY = PositionY - deltaY_2
+		elseif vy > 0 then
+			DestinationY = PositionY + deltaY_2
+		else
+			DestinationY = PositionY
+		end
+	end
+
+
+	-- if deltaX_2 > deltaY_2 then
+	-- 	DestinationX = ENV_WIDTH
+	-- 	DestinationY = PositionY + deltaY_2
+	-- elseif deltaX_2 < deltaY_2 then
+	-- 	DestinationX = PositionX + deltaX_2
+	-- 	DestinationY = ENV_HEIGHT
+	-- else
+	-- 	DestinationX = ENV_WIDTH
+	-- 	DestinationY = ENV_HEIGHT
+	-- end
+
+	ranaLibMovement.setSpeed(speed)
+	Moving = true
 
 end
 	

--- a/modules/ranalib_statistic.lua
+++ b/modules/ranalib_statistic.lua
@@ -8,6 +8,26 @@ function ranaLibStat.randomInteger(int1, int2)
 	return l_getRandomInteger(int1,int2)
 end
 
+-- Fetch a  pseudo-random int, which follows a Bernouilli distribution
+-- with given probability.
+function ranaLibStat.bernouilliInt(prob)
+	return l_getBernouilliInt(prob)
+end
+
+-- Fetch a  pseudo-random float, which follows a Gaussian distribution
+-- with given mean and variance.
+-- Precision is 64 bit.
+function ranaLibStat.gaussianFloat(mean, var)
+	return l_getGaussianFloat(mean, var)
+end
+
+-- Fetch a  pseudo-random float, which follows a Poisson distribution
+-- with given mean (expected ocurrences).
+-- Precision is 64 bit.
+function ranaLibStat.poissonFloat(mean)
+	return l_getPoissonFloat(mean)
+end
+
 -- Fetch a pseudo-random signed float between 'float1 and float2'.
 -- Precision is 64 bit.
 function ranaLibStat.randomFloat(float1, float2)

--- a/src/api/phys.cpp
+++ b/src/api/phys.cpp
@@ -154,7 +154,14 @@ int64_t Phys::getMersenneInteger(int64_t min=0, int64_t max=ULLONG_MAX)
     return min + Phys::int_dist(Phys::rng)%(max-min);
 }
 
-double  Phys::getGaussianFloat(double mean=0, double var=1)
+int Phys::getBernouilliInt(double probability=0.5)
+{
+    std::bernoulli_distribution bernouilli(probability);
+    int value = bernouilli(Phys::rng);
+    return value;
+}
+
+double Phys::getGaussianFloat(double mean=0, double var=1)
 {
     std::normal_distribution<> gauss(mean, var);
     double value = gauss(Phys::rng);

--- a/src/api/phys.cpp
+++ b/src/api/phys.cpp
@@ -153,3 +153,22 @@ int64_t Phys::getMersenneInteger(int64_t min=0, int64_t max=ULLONG_MAX)
     //return rand() %max;
     return min + Phys::int_dist(Phys::rng)%(max-min);
 }
+
+double  Phys::getGaussianFloat(double mean=0, double var=1)
+{
+    std::normal_distribution<> gauss(mean, var);
+    double value = gauss(Phys::rng);
+    return value;
+}
+
+double Phys::getPoissonFloat(int mean=1)
+{
+    double value = 0;
+    // Poisson distribution only works with positive integers.
+    if (mean > 0)
+    {
+        std::poisson_distribution<> poisson(mean);
+        value = poisson(Phys::rng);
+    }
+    return value;
+}

--- a/src/api/phys.h
+++ b/src/api/phys.h
@@ -73,6 +73,8 @@ class Phys
 
 		static double getMersenneFloat(double min, double max);
         static int64_t getMersenneInteger(int64_t min, int64_t max);
+		static double getGaussianFloat(double mean, double var);
+		static double getPoissonFloat(int mean);
 
 		static void setEnvironment(double x, double y);
 

--- a/src/api/phys.h
+++ b/src/api/phys.h
@@ -73,6 +73,7 @@ class Phys
 
 		static double getMersenneFloat(double min, double max);
         static int64_t getMersenneInteger(int64_t min, int64_t max);
+		static int getBernouilliInt(double probability);
 		static double getGaussianFloat(double mean, double var);
 		static double getPoissonFloat(int mean);
 

--- a/src/modules/ranalib_statistic.lua
+++ b/src/modules/ranalib_statistic.lua
@@ -8,6 +8,20 @@ function ranaLibStat.randomInteger(int1, int2)
 	return l_getRandomInteger(int1,int2)
 end
 
+-- Fetch a  pseudo-random float, which follows a Gaussian distribution
+-- with given mean and variance.
+-- Precision is 64 bit.
+function ranaLibStat.gaussianFloat(mean, var)
+	return l_getGaussianFloat(mean, var)
+end
+
+-- Fetch a  pseudo-random float, which follows a Poisson distribution
+-- with given mean (expected ocurrences).
+-- Precision is 64 bit.
+function ranaLibStat.poissonFloat(mean)
+	return l_getPoissonFloat(mean)
+end
+
 -- Fetch a pseudo-random signed float between 'float1 and float2'.
 -- Precision is 64 bit.
 function ranaLibStat.randomFloat(float1, float2)

--- a/src/modules/ranalib_statistic.lua
+++ b/src/modules/ranalib_statistic.lua
@@ -8,6 +8,12 @@ function ranaLibStat.randomInteger(int1, int2)
 	return l_getRandomInteger(int1,int2)
 end
 
+-- Fetch a  pseudo-random int, which follows a Bernouilli distribution
+-- with given probability.
+function ranaLibStat.bernouilliInt(prob)
+	return l_getBernouilliInt(prob)
+end
+
 -- Fetch a  pseudo-random float, which follows a Gaussian distribution
 -- with given mean and variance.
 -- Precision is 64 bit.

--- a/src/simulationcore/agents/agentluainterface.cpp
+++ b/src/simulationcore/agents/agentluainterface.cpp
@@ -160,6 +160,8 @@ AgentLuaInterface::AgentLuaInterface(int ID, double posX, double posY, double po
         lua_register(L, "l_getRandomFloat", l_getMersenneFloat);
         lua_register(L, "l_getRandomInteger", l_getMersenneInteger);
         lua_register(L, "l_getMersenneInteger", l_getMersenneInteger);
+        lua_register(L, "l_getGaussianFloat", l_getGaussianFloat);
+        lua_register(L, "l_getPoissonFloat", l_getPoissonFloat);
 
         //Map and movement.
         lua_register(L, "l_getEnvironmentSize", l_getEnvironmentSize);
@@ -794,6 +796,27 @@ int AgentLuaInterface::l_getMersenneInteger(lua_State *L)
     }
 
     lua_pushnumber(L,number);
+    return 1;
+}
+
+int AgentLuaInterface::l_getGaussianFloat(lua_State *L)
+{
+    double mean = lua_tonumber(L,-2);
+    double var = lua_tonumber(L, -1);
+
+    double number = Phys::getGaussianFloat(mean, var);
+
+    lua_pushnumber(L, number);
+    return 1;
+}
+
+int AgentLuaInterface::l_getPoissonFloat(lua_State *L)
+{
+    double mean = lua_tonumber(L,-1);
+
+    double number = Phys::getPoissonFloat(mean);
+
+    lua_pushnumber(L, number);
     return 1;
 }
 

--- a/src/simulationcore/agents/agentluainterface.cpp
+++ b/src/simulationcore/agents/agentluainterface.cpp
@@ -160,6 +160,7 @@ AgentLuaInterface::AgentLuaInterface(int ID, double posX, double posY, double po
         lua_register(L, "l_getRandomFloat", l_getMersenneFloat);
         lua_register(L, "l_getRandomInteger", l_getMersenneInteger);
         lua_register(L, "l_getMersenneInteger", l_getMersenneInteger);
+        lua_register(L, "l_getBernouilliInt", l_getBernouilliInt);
         lua_register(L, "l_getGaussianFloat", l_getGaussianFloat);
         lua_register(L, "l_getPoissonFloat", l_getPoissonFloat);
 
@@ -796,6 +797,16 @@ int AgentLuaInterface::l_getMersenneInteger(lua_State *L)
     }
 
     lua_pushnumber(L,number);
+    return 1;
+}
+
+int AgentLuaInterface::l_getBernouilliInt(lua_State *L)
+{
+    double prob = lua_tonumber(L, -1);
+
+    int value = Phys::getBernouilliInt(prob);
+    
+    lua_pushnumber(L, value);
     return 1;
 }
 

--- a/src/simulationcore/agents/agentluainterface.h
+++ b/src/simulationcore/agents/agentluainterface.h
@@ -70,6 +70,7 @@ public:
     static int l_getTimeResolution(lua_State *L);
     static int l_getMersenneFloat(lua_State *L);
     static int l_getMersenneInteger(lua_State *L);
+    static int l_getBernouilliInt(lua_State *L);
     static int l_getGaussianFloat(lua_State *L);
     static int l_getPoissonFloat(lua_State *L);
 

--- a/src/simulationcore/agents/agentluainterface.h
+++ b/src/simulationcore/agents/agentluainterface.h
@@ -70,6 +70,8 @@ public:
     static int l_getTimeResolution(lua_State *L);
     static int l_getMersenneFloat(lua_State *L);
     static int l_getMersenneInteger(lua_State *L);
+    static int l_getGaussianFloat(lua_State *L);
+    static int l_getPoissonFloat(lua_State *L);
 
     //Map and movement.
     static int l_getEnvironmentSize(lua_State *L);


### PR DESCRIPTION
Add functions for getting Gaussian, Poisson, and Bernouilli numbers in the RANA core.

Also, allow to use the parameters specified in the lua sim file for running non-gui simulations. There was a condition LUA_OK!=true that was always forcing the default values to be used.